### PR TITLE
fix(website): align footer padding and resolve AntigravityIcon hydration mismatch

### DIFF
--- a/web/apps/website/src/components/website-footer.tsx
+++ b/web/apps/website/src/components/website-footer.tsx
@@ -28,7 +28,7 @@ const footerLinks = {
 export function WebsiteFooter() {
   return (
     <footer className="border-t border-foreground/10 mt-20">
-      <div className="mx-auto max-w-6xl px-6 py-16">
+      <div className="mx-auto max-w-7xl px-6 lg:px-12 py-16">
         <div className="grid grid-cols-2 gap-8 md:grid-cols-4">
           {/* Logo and tagline */}
           <div className="col-span-2 md:col-span-1">

--- a/web/packages/ui/src/icons.tsx
+++ b/web/packages/ui/src/icons.tsx
@@ -1,5 +1,3 @@
-import { useId } from 'react'
-
 interface IconProps {
   className?: string
 }
@@ -104,9 +102,8 @@ export function JetBrainsIcon({ className = 'h-4 w-4' }: IconProps) {
 }
 
 export function AntigravityIcon({ className = 'h-4 w-4' }: IconProps) {
-  const id = useId()
-  const clipId = `antigravity-clip-${id}`
-  const filterId = (n: number) => `filter${n}-${id}`
+  const clipId = 'antigravity-clip'
+  const filterId = (n: number) => `antigravity-filter-${n}`
 
   return (
     <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>


### PR DESCRIPTION
## Summary
- **Footer padding** — footer used `max-w-6xl px-6` while page sections above use `max-w-7xl px-6 lg:px-12`, leaving footer columns inset on wide screens. Match the page container so columns line up.
- **AntigravityIcon hydration error** — `useId()` produced different values on server vs client (Radix `ScrollArea` shifted the useId counter), causing the SVG `clipPath`/`filter` ids to mismatch. Replaced with stable literal ids; ids are only referenced inside the same SVG so this is safe.

## Before / After (1440px viewport)
- **Footer alignment:** before — logo at ~190px, content above at ~140px; after — both align at ~140px
- **Hydration:** before — Next.js dev overlay showed "1 Issue" with a hydration error; after — no issues

## Test plan
- [ ] Visual check at 1440px — footer columns align with page content above
- [ ] Visual check at md / sm breakpoints — no regressions
- [ ] No Next.js dev overlay issues on home page load
- [ ] AntigravityIcon still renders correctly in the IDE list