### PR TITLE
fix: cloud-init brace expansion and RBAC cleanup context

### DIFF
--- a/controllers/workmachine/templates/k3s-agent-setup-azure.yml
+++ b/controllers/workmachine/templates/k3s-agent-setup-azure.yml
@@ -16,7 +16,7 @@ mounts:
   - ["/dev/disk/azure/scsi1/lun0", "/var/lib/kloudlite/storage", "btrfs", "noatime,compress=zstd", "0", "0"]
 
 runcmd:
-  - mkdir -p /var/lib/kloudlite/storage/{environments,workspaces,.snapshots}
+  - [mkdir, -p, /var/lib/kloudlite/storage/environments, /var/lib/kloudlite/storage/workspaces, /var/lib/kloudlite/storage/.snapshots]
   - swapoff -a
   - sed -i '/ swap / s/^/#/' /etc/fstab
   - mkdir -p /etc/rancher/k3s

--- a/controllers/workmachine/templates/k3s-agent-setup-gcp.yml
+++ b/controllers/workmachine/templates/k3s-agent-setup-gcp.yml
@@ -16,7 +16,7 @@ mounts:
   - ["/dev/sdb", "/var/lib/kloudlite/storage", "btrfs", "noatime,compress=zstd", "0", "0"]
 
 runcmd:
-  - mkdir -p /var/lib/kloudlite/storage/{environments,workspaces,.snapshots}
+  - [mkdir, -p, /var/lib/kloudlite/storage/environments, /var/lib/kloudlite/storage/workspaces, /var/lib/kloudlite/storage/.snapshots]
   - swapoff -a
   - sed -i '/ swap / s/^/#/' /etc/fstab
   - mkdir -p /etc/rancher/k3s

--- a/controllers/workmachine/templates/k3s-agent-setup-oci.yml
+++ b/controllers/workmachine/templates/k3s-agent-setup-oci.yml
@@ -16,7 +16,7 @@ mounts:
   - ["/dev/sdb", "/var/lib/kloudlite/storage", "btrfs", "noatime,compress=zstd", "0", "0"]
 
 runcmd:
-  - mkdir -p /var/lib/kloudlite/storage/{environments,workspaces,.snapshots}
+  - [mkdir, -p, /var/lib/kloudlite/storage/environments, /var/lib/kloudlite/storage/workspaces, /var/lib/kloudlite/storage/.snapshots]
   - swapoff -a
   - sed -i '/ swap / s/^/#/' /etc/fstab
   - mkdir -p /etc/rancher/k3s

--- a/controllers/workspace/workspace_controller.go
+++ b/controllers/workspace/workspace_controller.go
@@ -581,9 +581,11 @@ func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // This ensures leaked resources are cleaned up promptly
 func (r *WorkspaceReconciler) enqueueForRBACCleanup(ctx context.Context, obj client.Object) []reconcile.Request {
 	// Run orphaned RBAC cleanup in the background
+	// Use context.Background() because the map function context has a short lifetime
+	// and would be canceled before cleanup completes
 	go func() {
 		r.Logger.Info("Triggering orphaned RBAC cleanup")
-		deletedCount, errors := r.cleanupOrphanedRBACResources(ctx, r.Logger)
+		deletedCount, errors := r.cleanupOrphanedRBACResources(context.Background(), r.Logger)
 		if len(errors) > 0 {
 			r.Logger.Warn("Triggered RBAC cleanup encountered errors",
 				zap.Int("deletedCount", deletedCount),


### PR DESCRIPTION
## Summary
- Fix cloud-init `runcmd` using bash brace expansion (`{environments,workspaces,.snapshots}`) which creates a single literal directory under `sh`. Changed to YAML list format in azure/gcp/oci templates.
- Fix RBAC orphan cleanup goroutine using the map function's short-lived context, causing `context canceled` errors. Use `context.Background()` instead.

## Test plan
- [x] Verified on Azure VM: storage directories created correctly after manual fix
- [ ] Rebuild api-server image to embed fixed templates, provision new VM, confirm directories
- [ ] Trigger RBAC orphan cleanup and verify no context canceled errors