### PR TITLE
fix: nil pointer panic in webhooks and register checkpoint controllers

### DIFF
--- a/api/webhooks/pod_mutation_webhook.go
+++ b/api/webhooks/pod_mutation_webhook.go
@@ -102,6 +102,10 @@ func (w *PodMutationWebhook) handleMutation(req *admissionv1.AdmissionRequest) *
 			continue
 		}
 
+		if environment.Status.ComposeStatus == nil {
+			continue
+		}
+
 		for _, activeIntercept := range environment.Status.ComposeStatus.ActiveIntercepts {
 			// Check if pod labels match the original service selector
 			if activeIntercept.OriginalServiceSelector != nil {

--- a/api/webhooks/service_mutation_webhook.go
+++ b/api/webhooks/service_mutation_webhook.go
@@ -94,6 +94,10 @@ func (w *ServiceMutationWebhook) handleMutation(req *admissionv1.AdmissionReques
 			continue
 		}
 
+		if environment.Status.ComposeStatus == nil {
+			continue
+		}
+
 		for _, activeIntercept := range environment.Status.ComposeStatus.ActiveIntercepts {
 			if activeIntercept.ServiceName == service.Name {
 				hasActiveIntercept = true

--- a/controllers/manager.go
+++ b/controllers/manager.go
@@ -200,6 +200,39 @@ func newMachineScopedManager(cfg *rest.Config, installationCfg *config.Installat
 		return nil, fmt.Errorf("unable to setup WorkMachine manager controller: %w", err)
 	}
 
+	// Setup Checkpoint controller with operator for registry operations
+	checkpointOperator := checkpoint.NewDefaultCheckpointOperator(logger.With(zap.String("component", "checkpoint-operator")))
+	checkpointReconciler := &checkpoint.CheckpointReconciler{
+		Client:             mgr.GetClient(),
+		Logger:             logger.With(zap.String("controller", "checkpoint")),
+		CheckpointOperator: checkpointOperator,
+	}
+	if err := checkpointReconciler.SetupWithManager(mgr); err != nil {
+		return nil, fmt.Errorf("unable to create Checkpoint controller: %w", err)
+	}
+
+	// Setup EnvironmentCheckpoint controller
+	envCheckpointReconciler := &environment.EnvironmentCheckpointReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Logger: logger.With(zap.String("controller", "environmentcheckpoint")),
+		Cfg:    controllerCfg,
+	}
+	if err := envCheckpointReconciler.SetupWithManager(mgr); err != nil {
+		return nil, fmt.Errorf("unable to create EnvironmentCheckpoint controller: %w", err)
+	}
+
+	// Setup EnvironmentCheckpointRestore controller
+	envCheckpointRestoreReconciler := &environment.EnvironmentCheckpointRestoreReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Logger: logger.With(zap.String("controller", "environmentcheckpointrestore")),
+		Cfg:    controllerCfg,
+	}
+	if err := envCheckpointRestoreReconciler.SetupWithManager(mgr); err != nil {
+		return nil, fmt.Errorf("unable to create EnvironmentCheckpointRestore controller: %w", err)
+	}
+
 	logger.Info("controllers initialized successfully", zap.Strings("controllers", MachineScopedControllerNames()))
 	return &Manager{mgr: mgr, logger: logger, ingressReconciler: ingressReconciler}, nil
 }


### PR DESCRIPTION
## Summary
- Fix nil pointer dereference in pod and service mutation webhooks when `environment.Status.ComposeStatus` is nil (newly created environments)
- Register Checkpoint, EnvironmentCheckpoint, and EnvironmentCheckpointRestore controllers in the machine-scoped manager — they were previously only in the unreachable `NewManager` code path

## Test plan
- [ ] Deploy updated API server and verify no panics in webhook logs when creating new environments
- [ ] Deploy updated workmachine-manager and verify checkpoint controllers start (look for "Starting Controller" logs with checkpoint controller names)
- [ ] Create an EnvironmentCheckpoint and verify it progresses through phases to completion