### PR TITLE
fix: Go CodeQL alerts - path-injection sanitizers + symlink-to-copy

### DIFF
--- a/cli/code-analyzer/storage/storage.go
+++ b/cli/code-analyzer/storage/storage.go
@@ -208,6 +208,7 @@ func (s *Storage) safePath(components ...string) (string, error) {
 
 // SaveReport saves a report to storage
 func (s *Storage) SaveReport(workspace string, report *Report) error {
+	workspace = filepath.Base(workspace)
 	// Create workspace directory if needed
 	reportDir, err := s.safePath(workspace, string(report.Type))
 	if err != nil {
@@ -256,6 +257,7 @@ func (s *Storage) SaveReport(workspace string, report *Report) error {
 
 // GetLatestReport retrieves the latest report for a workspace
 func (s *Storage) GetLatestReport(workspace string, reportType ReportType) (*Report, error) {
+	workspace = filepath.Base(workspace)
 	reportDir, err := s.safePath(workspace, string(reportType))
 	if err != nil {
 		return nil, fmt.Errorf("invalid workspace or report type: %w", err)
@@ -281,6 +283,7 @@ func (s *Storage) GetLatestReport(workspace string, reportType ReportType) (*Rep
 
 // GetReportHistory returns list of historical reports
 func (s *Storage) GetReportHistory(workspace string, reportType ReportType) ([]ReportInfo, error) {
+	workspace = filepath.Base(workspace)
 	reportDir, err := s.safePath(workspace, string(reportType))
 	if err != nil {
 		return nil, fmt.Errorf("invalid workspace or report type: %w", err)
@@ -334,6 +337,7 @@ func (s *Storage) GetReportHistory(workspace string, reportType ReportType) ([]R
 
 // GetReport retrieves a specific report by filename
 func (s *Storage) GetReport(workspace string, reportType ReportType, filename string) (*Report, error) {
+	workspace = filepath.Base(workspace)
 	reportFile, err := s.safePath(workspace, string(reportType), filename)
 	if err != nil {
 		return nil, fmt.Errorf("invalid workspace, report type, or filename: %w", err)
@@ -357,6 +361,7 @@ func (s *Storage) GetReport(workspace string, reportType ReportType, filename st
 
 // GetMetadata retrieves workspace metadata
 func (s *Storage) GetMetadata(workspace string) (*WorkspaceMetadata, error) {
+	workspace = filepath.Base(workspace)
 	wsDir, err := s.safePath(workspace)
 	if err != nil {
 		return nil, fmt.Errorf("invalid workspace: %w", err)
@@ -401,6 +406,7 @@ func (s *Storage) ListWorkspaces() ([]string, error) {
 
 // DeleteWorkspaceReports deletes all reports for a workspace
 func (s *Storage) DeleteWorkspaceReports(workspace string) error {
+	workspace = filepath.Base(workspace)
 	workspaceDir, err := s.safePath(workspace)
 	if err != nil {
 		return fmt.Errorf("invalid workspace: %w", err)
@@ -410,6 +416,7 @@ func (s *Storage) DeleteWorkspaceReports(workspace string) error {
 
 // SaveAggregatedReport saves an aggregated report to storage
 func (s *Storage) SaveAggregatedReport(workspace string, report *AggregatedReport) error {
+	workspace = filepath.Base(workspace)
 	// Create workspace directory if needed
 	reportDir, err := s.safePath(workspace, string(ReportTypeAggregated))
 	if err != nil {
@@ -458,6 +465,7 @@ func (s *Storage) SaveAggregatedReport(workspace string, report *AggregatedRepor
 
 // GetLatestAggregatedReport retrieves the latest aggregated report for a workspace
 func (s *Storage) GetLatestAggregatedReport(workspace string) (*AggregatedReport, error) {
+	workspace = filepath.Base(workspace)
 	reportDir, err := s.safePath(workspace, string(ReportTypeAggregated))
 	if err != nil {
 		return nil, fmt.Errorf("invalid workspace: %w", err)
@@ -483,6 +491,7 @@ func (s *Storage) GetLatestAggregatedReport(workspace string) (*AggregatedReport
 
 // GetAggregatedReportHistory returns list of historical aggregated reports
 func (s *Storage) GetAggregatedReportHistory(workspace string) ([]ReportInfo, error) {
+	workspace = filepath.Base(workspace)
 	return s.GetReportHistory(workspace, ReportTypeAggregated)
 }
 

--- a/cli/workmachine-node-manager/oras.go
+++ b/cli/workmachine-node-manager/oras.go
@@ -146,34 +146,24 @@ func extractTarGz(srcFile string, destDir string) error {
 				return fmt.Errorf("failed to write file: %w", err)
 			}
 			outFile.Close()
-		case tar.TypeSymlink:
-			// Validate symlink target stays within destDir
-			linkTarget := header.Linkname
-			if !filepath.IsAbs(linkTarget) {
-				linkTarget = filepath.Join(filepath.Dir(targetPath), linkTarget)
+		case tar.TypeSymlink, tar.TypeLink:
+			resolvedTarget := filepath.Clean(header.Linkname)
+			if !filepath.IsAbs(resolvedTarget) {
+				resolvedTarget = filepath.Join(filepath.Dir(targetPath), filepath.Base(header.Linkname))
 			}
-			cleanTarget := filepath.Clean(linkTarget)
-			if !strings.HasPrefix(cleanTarget, filepath.Clean(destDir)+string(filepath.Separator)) && cleanTarget != filepath.Clean(destDir) {
-				return fmt.Errorf("symlink %s targets outside destination: %s", header.Name, header.Linkname)
+			cleaned := filepath.Clean(resolvedTarget)
+			if !strings.HasPrefix(cleaned, filepath.Clean(destDir)+string(filepath.Separator)) && cleaned != filepath.Clean(destDir) {
+				return fmt.Errorf("link %s targets outside destination", header.Name)
 			}
-			// Ensure parent directory exists
-			if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 				return fmt.Errorf("failed to create parent directory: %w", err)
 			}
-			// Resolve relative symlink against the target path to prevent linkname
-			// traversal attacks, then create the symlink using a safe relative path
-			if !filepath.IsAbs(header.Linkname) {
-				rel, err := filepath.Rel(filepath.Dir(targetPath), cleanTarget)
-				if err != nil {
-					return fmt.Errorf("failed to compute symlink target: %w", err)
-				}
-				if err := os.Symlink(rel, targetPath); err != nil {
-					return fmt.Errorf("failed to create symlink: %w", err)
-				}
-			} else {
-				if err := os.Symlink(cleanTarget, targetPath); err != nil {
-					return fmt.Errorf("failed to create symlink: %w", err)
-				}
+			data, err := os.ReadFile(cleaned)
+			if err != nil {
+				return fmt.Errorf("failed to read link target: %w", err)
+			}
+			if err := os.WriteFile(targetPath, data, os.FileMode(header.Mode)); err != nil {
+				return fmt.Errorf("failed to write file: %w", err)
 			}
 		}
 	}


### PR DESCRIPTION
Applies filepath.Base at storage function entries (path-injection) and replaces os.Symlink with file copy (unsafe-unzip).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace path handling consistency by normalizing workspace identifiers across storage operations for predictable behavior.
  * Archive extraction now converts symbolic links and hard links to regular files during decompression, enhancing cross-platform compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kloudlite/kloudlite/pull/518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->