### PR TITLE
fix: use golang:1.25-alpine in Dagger build to match go.mod

### DIFF
--- a/build-sys/go_build.go
+++ b/build-sys/go_build.go
@@ -150,7 +150,7 @@ func (m *Kloudlite) buildGoBinary(
 	goBuildCache := dag.CacheVolume("go-build-v1")
 
 	ctr := dag.Container().
-		From("golang:1.24-alpine").
+		From("golang:1.25-alpine").
 		WithExec([]string{"apk", "add", "--no-cache", "git", "curl", "bash", "build-base"}).
 		WithMountedCache("/go/pkg/mod", goModCache).
 		WithMountedCache("/root/.cache/go-build", goBuildCache).


### PR DESCRIPTION
The buildGoBinary function used golang:1.24-alpine which caused controller-gen to fail with 'go.mod requires go >= 1.25.0'. Changed to golang:1.25-alpine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version to 1.25 for all binary builds, enabling access to latest compiler improvements and security patches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kloudlite/kloudlite/pull/519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->