### PR TITLE
Polish desktop shortcuts and tab picker

### DIFF
--- a/web/apps/desktop/src/main/index.ts
+++ b/web/apps/desktop/src/main/index.ts
@@ -1,6 +1,6 @@
 // MUST be first import — caches V8 bytecode for 20-30% faster startup
 import 'v8-compile-cache'
-import { app, BrowserWindow, globalShortcut, Menu, MenuItem, nativeImage, nativeTheme, shell, ipcMain, webContents } from 'electron'
+import { app, BrowserWindow, Menu, MenuItem, nativeImage, nativeTheme, shell, ipcMain, webContents } from 'electron'
 
 // Disable hardware acceleration check — skip GPU init for faster startup on some systems
 // app.disableHardwareAcceleration()  // Uncomment if GPU init is slow
@@ -27,6 +27,40 @@ function setDockIcon(): void {
   if (process.platform !== 'darwin') return
   const icon = nativeImage.createFromPath(join(__dirname, '../../resources/icon.png'))
   if (!icon.isEmpty()) app.dock?.setIcon(icon)
+}
+
+function shortcutAction(input: Electron.Input): string | null {
+  const key = input.key.toLowerCase()
+  const cmdOrCtrl = input.meta || input.control
+
+  if (input.control && key === 'tab') return input.shift ? 'prev-tab' : 'next-tab'
+  if (cmdOrCtrl && key === 't') return 'new-tab'
+  if (cmdOrCtrl && key === 'l') return 'address-bar'
+  if (cmdOrCtrl && key === 'w') return 'close-tab'
+  if (cmdOrCtrl && key === 'r') return 'reload'
+  if (cmdOrCtrl && key === 's') return 'toggle-sidebar'
+  if (cmdOrCtrl && key === '1') return 'mode-1'
+  if (cmdOrCtrl && key === '2') return 'mode-2'
+  if (cmdOrCtrl && key === '3') return 'mode-3'
+  if (cmdOrCtrl && (key === '[' || key === 'left')) return 'go-back'
+  if (cmdOrCtrl && (key === ']' || key === 'right')) return 'go-forward'
+  if (input.alt && !input.meta && !input.control && !input.shift && key === 'left') return 'go-back'
+  if (input.alt && !input.meta && !input.control && !input.shift && key === 'right') return 'go-forward'
+
+  return null
+}
+
+function sendShortcut(action: string): void {
+  BrowserWindow.getFocusedWindow()?.webContents.send('shortcut', action)
+}
+
+function installWindowShortcuts(contents: Electron.WebContents): void {
+  contents.on('before-input-event', (event, input) => {
+    const action = shortcutAction(input)
+    if (!action) return
+    event.preventDefault()
+    sendShortcut(action)
+  })
 }
 
 function createWindow(): BrowserWindow {
@@ -57,6 +91,7 @@ function createWindow(): BrowserWindow {
     mainWindow.show()
   })
 
+  installWindowShortcuts(mainWindow.webContents)
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
     shell.openExternal(details.url)
@@ -127,6 +162,21 @@ function createAppMenu(): void {
         },
         { type: 'separator' },
         {
+          label: 'Next Tab',
+          accelerator: 'Ctrl+Tab',
+          click: (_item, window) => {
+            sendToMenuWindow(window, 'shortcut', 'next-tab')
+          }
+        },
+        {
+          label: 'Previous Tab',
+          accelerator: 'Ctrl+Shift+Tab',
+          click: (_item, window) => {
+            sendToMenuWindow(window, 'shortcut', 'prev-tab')
+          }
+        },
+        { type: 'separator' },
+        {
           label: 'Reload Tab',
           accelerator: 'CmdOrCtrl+R',
           click: (_item, window) => {
@@ -149,14 +199,6 @@ function createAppMenu(): void {
           visible: false
         },
         {
-          label: 'Go Back (Alt Arrow)',
-          accelerator: 'Alt+Left',
-          click: (_item, window) => {
-            sendToMenuWindow(window, 'shortcut', 'go-back')
-          },
-          visible: false
-        },
-        {
           label: 'Go Forward',
           accelerator: 'CmdOrCtrl+]',
           click: (_item, window) => {
@@ -166,14 +208,6 @@ function createAppMenu(): void {
         {
           label: 'Go Forward (Arrow)',
           accelerator: 'CmdOrCtrl+Right',
-          click: (_item, window) => {
-            sendToMenuWindow(window, 'shortcut', 'go-forward')
-          },
-          visible: false
-        },
-        {
-          label: 'Go Forward (Alt Arrow)',
-          accelerator: 'Alt+Right',
           click: (_item, window) => {
             sendToMenuWindow(window, 'shortcut', 'go-forward')
           },
@@ -544,6 +578,7 @@ ipcMain.handle('api:patch-resource', async (_event, namespace: string | null, re
 // Handle new-window for webview guests — prevent popups, navigate in app instead
 app.on('web-contents-created', (_event, contents) => {
   if (contents.getType() === 'webview') {
+    installWindowShortcuts(contents)
     contents.setWindowOpenHandler(({ url, disposition }) => {
       const win = BrowserWindow.getAllWindows()[0]
       if (win) {
@@ -575,20 +610,6 @@ app.whenReady().then(() => {
 
     // Start browser MCP server for AI control
     startMCPServer()
-
-    // Register global shortcuts
-    globalShortcut.register('Ctrl+Tab', () => {
-      const win = BrowserWindow.getFocusedWindow()
-      win?.webContents.send('shortcut', 'next-tab')
-    })
-    globalShortcut.register('Ctrl+Shift+Tab', () => {
-      const win = BrowserWindow.getFocusedWindow()
-      win?.webContents.send('shortcut', 'prev-tab')
-    })
-    globalShortcut.register('CommandOrControl+S', () => {
-      const win = BrowserWindow.getFocusedWindow()
-      win?.webContents.send('shortcut', 'toggle-sidebar')
-    })
   })
 
   app.on('activate', () => {

--- a/web/apps/desktop/src/preload/webview.ts
+++ b/web/apps/desktop/src/preload/webview.ts
@@ -6,6 +6,35 @@ document.addEventListener('contextmenu', (e) => {
   ipcRenderer.sendToHost('context-menu', e.screenX, e.screenY)
 })
 
+function isEditable(target: EventTarget | null) {
+  const el = target as HTMLElement | null
+  if (!el) return false
+  return el.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(el.tagName)
+}
+
+window.addEventListener('keydown', (e) => {
+  if (e.ctrlKey && e.key === 'Tab') {
+    e.preventDefault()
+    ipcRenderer.sendToHost('shortcut', e.shiftKey ? 'prev-tab' : 'next-tab')
+    return
+  }
+
+  if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'r') {
+    e.preventDefault()
+    ipcRenderer.sendToHost('shortcut', 'reload')
+    return
+  }
+
+  if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey || isEditable(e.target)) return
+  if (e.key === 'ArrowLeft') {
+    e.preventDefault()
+    ipcRenderer.sendToHost('shortcut', 'go-back')
+  } else if (e.key === 'ArrowRight') {
+    e.preventDefault()
+    ipcRenderer.sendToHost('shortcut', 'go-forward')
+  }
+}, true)
+
 // Simple swipe detection — no visual, just back/forward action
 let accumulator = 0
 let idleTimer: ReturnType<typeof setTimeout> | null = null

--- a/web/apps/desktop/src/renderer/app.tsx
+++ b/web/apps/desktop/src/renderer/app.tsx
@@ -169,13 +169,19 @@ export function App() {
           break
         }
         case 'reload':
-          getActiveReload()
+          if (currentMode === 'environments') envHandleRef.current?.reload()
+          else if (currentMode === 'workspaces') wsHandleRef.current?.reload()
+          else handleRef.current?.reload()
           break
         case 'go-back':
-          getActiveGoBack()
+          if (currentMode === 'environments') envHandleRef.current?.goBack()
+          else if (currentMode === 'workspaces') wsHandleRef.current?.goBack()
+          else handleRef.current?.goBack()
           break
         case 'go-forward':
-          getActiveGoForward()
+          if (currentMode === 'environments') envHandleRef.current?.goForward()
+          else if (currentMode === 'workspaces') wsHandleRef.current?.goForward()
+          else handleRef.current?.goForward()
           break
         case 'toggle-sidebar':
           setSidebarVisible((v) => !v)
@@ -189,6 +195,56 @@ export function App() {
           break
       }
     })
+  }, [])
+
+  useEffect(() => {
+    function isEditable(target: EventTarget | null) {
+      const el = target as HTMLElement | null
+      if (!el) return false
+      return el.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(el.tagName)
+    }
+
+    function selectRelativeTab(offset: 1 | -1) {
+      const { tabs, activeTabId, setActiveTab } = useTabStore.getState()
+      if (tabs.length < 2) return
+      const idx = tabs.findIndex((t) => t.id === activeTabId)
+      if (idx === -1) return
+      setActiveTab(tabs[(idx + offset + tabs.length) % tabs.length].id)
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      const currentMode = useModeStore.getState().mode
+
+      if (e.ctrlKey && e.key === 'Tab') {
+        e.preventDefault()
+        if (currentMode === 'browse') selectRelativeTab(e.shiftKey ? -1 : 1)
+        return
+      }
+
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'r') {
+        e.preventDefault()
+        if (currentMode === 'environments') envHandleRef.current?.reload()
+        else if (currentMode === 'workspaces') wsHandleRef.current?.reload()
+        else handleRef.current?.reload()
+        return
+      }
+
+      if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey || isEditable(e.target)) return
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault()
+        if (currentMode === 'environments') envHandleRef.current?.goBack()
+        else if (currentMode === 'workspaces') wsHandleRef.current?.goBack()
+        else handleRef.current?.goBack()
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault()
+        if (currentMode === 'environments') envHandleRef.current?.goForward()
+        else if (currentMode === 'workspaces') wsHandleRef.current?.goForward()
+        else handleRef.current?.goForward()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown, true)
+    return () => window.removeEventListener('keydown', handleKeyDown, true)
   }, [])
 
   // Loading indicator with fade-out (browse mode only)

--- a/web/apps/desktop/src/renderer/components/command-bar.tsx
+++ b/web/apps/desktop/src/renderer/components/command-bar.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, useMemo, useCallback, type KeyboardEvent }
 import { Search, ArrowRight, Globe } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useTabStore, type Tab } from '@/store/tabs'
-import { useEnvironmentStore } from '@/store/environments'
+import { DUMMY_ENVIRONMENTS, useEnvironmentStore } from '@/store/environments'
 
 const ENTER_ANIM = 'popover-in 150ms ease-out'
 const EXIT_ANIM = 'popover-out 150ms ease-in forwards'
@@ -33,7 +33,8 @@ interface NewTabBarProps {
 
 export function NewTabBar({ onNavigate, onClose }: NewTabBarProps) {
   const { tabs, activeTabId, setActiveTab, addTab } = useTabStore()
-  const selectedEnv = useEnvironmentStore((s) => s.environments.find(e => e.id === s.selectedEnvironmentId))
+  const environments = useEnvironmentStore((s) => s.environments)
+  const browseEnvironments = environments.length > 0 ? environments : DUMMY_ENVIRONMENTS
   const [query, setQuery] = useState('')
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [exiting, setExiting] = useState(false)
@@ -59,16 +60,18 @@ export function NewTabBar({ onNavigate, onClose }: NewTabBarProps) {
 
   // Filter available services (not already open)
   const availableServices = useMemo(() => {
-    if (!selectedEnv) return []
-    const services = selectedEnv.services.filter((s) => !openTabUrls.has(normalizeForDedup(s.vpnUrl)))
+    const services = browseEnvironments.flatMap((env) =>
+      env.services.map((svc) => ({ ...svc, envName: env.name }))
+    ).filter((s) => !openTabUrls.has(normalizeForDedup(s.vpnUrl)))
     const q = query.toLowerCase().trim()
     if (!q) return services
     return services.filter((s) =>
       s.name.toLowerCase().includes(q) ||
+      s.envName.toLowerCase().includes(q) ||
       s.dnsHostname.toLowerCase().includes(q) ||
       String(s.port).includes(q)
     )
-  }, [query, selectedEnv, openTabUrls])
+  }, [query, browseEnvironments, openTabUrls])
 
   const totalItems = filteredOpenTabs.length + availableServices.length
 
@@ -133,7 +136,7 @@ export function NewTabBar({ onNavigate, onClose }: NewTabBarProps) {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder={`Search services${selectedEnv ? ` in ${selectedEnv.name}` : ''}...`}
+            placeholder="Search services..."
             spellCheck={false}
           />
         </div>
@@ -145,7 +148,7 @@ export function NewTabBar({ onNavigate, onClose }: NewTabBarProps) {
               <div
                 key={tab.id}
                 className={cn(
-                  'mx-1.5 flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 transition-colors',
+                  'group mx-1.5 flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 transition-colors',
                   i === selectedIndex ? 'bg-accent/80' : 'hover:bg-accent/50'
                 )}
                 onClick={() => { setActiveTab(tab.id); close() }}
@@ -159,7 +162,10 @@ export function NewTabBar({ onNavigate, onClose }: NewTabBarProps) {
                   <span className="block truncate text-[13px] text-foreground">{tab.title || 'New Tab'}</span>
                   <span className="block truncate text-[11px] text-muted-foreground/60">{extractDomain(tab.url)}</span>
                 </div>
-                <span className="flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground">
+                <span className={cn(
+                  'flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100',
+                  i === selectedIndex && 'opacity-100'
+                )}>
                   Switch to Tab <ArrowRight className="h-3 w-3" />
                 </span>
               </div>
@@ -168,28 +174,26 @@ export function NewTabBar({ onNavigate, onClose }: NewTabBarProps) {
             {/* Available services */}
             {availableServices.length > 0 && (
               <>
-                {filteredOpenTabs.length > 0 && (
-                  <div className="mx-4 my-1 flex items-center gap-2 border-t border-border/20 pt-2">
-                    <span className="text-[11px] font-medium text-muted-foreground/50">Services</span>
-                  </div>
-                )}
+                <div className={cn('mx-4 mb-1 flex items-center gap-2', filteredOpenTabs.length > 0 && 'mt-1 border-t border-border/20 pt-2')}>
+                  <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/45">HTTP services</span>
+                </div>
                 {availableServices.map((svc, i) => (
                   <div
-                    key={svc.id}
+                    key={`${svc.envName}-${svc.id}`}
                     className={cn(
-                      'mx-1.5 flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 transition-colors',
-                      filteredOpenTabs.length + i === selectedIndex ? 'bg-accent/80' : 'hover:bg-accent/50'
+                      'mx-1.5 flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2 transition-colors',
+                      filteredOpenTabs.length + i === selectedIndex ? 'bg-accent/75' : 'hover:bg-accent/45'
                     )}
                     onClick={() => { addTab(svc.vpnUrl); close() }}
                   >
-                    <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-emerald-500/10">
-                      <div className="h-2 w-2 rounded-full bg-emerald-500" />
-                    </div>
+                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-emerald-500/10">
+                      <span className="h-2 w-2 rounded-full bg-emerald-500" />
+                    </span>
                     <div className="min-w-0 flex-1">
-                      <span className="block truncate text-[13px] text-foreground">{svc.name}</span>
-                      <span className="block truncate text-[11px] text-muted-foreground/60">{svc.dnsHostname}</span>
+                      <span className="block truncate text-[13px] font-medium text-foreground">{svc.envName}/{svc.name}</span>
+                      <span className="block truncate text-[11px] text-muted-foreground/55">{svc.dnsHostname}</span>
                     </div>
-                    <span className="text-[11px] text-muted-foreground/40">Open</span>
+                    <span className="rounded-md bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">:{svc.port}</span>
                   </div>
                 ))}
               </>

--- a/web/apps/desktop/src/renderer/components/sidebar-browse.tsx
+++ b/web/apps/desktop/src/renderer/components/sidebar-browse.tsx
@@ -1,124 +1,17 @@
-import { Plus, ChevronDown, Globe } from 'lucide-react'
-import { useState } from 'react'
-import { cn } from '@/lib/utils'
+import { Plus } from 'lucide-react'
 import { useTabStore } from '@/store/tabs'
-import { useEnvironmentStore, type Environment } from '@/store/environments'
 import { TabItem } from './tab-item'
 
-const DUMMY_ENVIRONMENTS: Environment[] = [
-  {
-    id: 'demo-production',
-    name: 'demo-production',
-    slug: 'demo-production',
-    status: 'active',
-    namespace: 'wm-demo',
-    services: [
-      { id: 'prod-api', name: 'api', port: 8080, dnsHostname: 'api.demo.local', vpnUrl: 'https://www.google.com' },
-      { id: 'prod-web', name: 'web', port: 3000, dnsHostname: 'web.demo.local', vpnUrl: 'https://news.ycombinator.com' },
-    ],
-  },
-  {
-    id: 'demo-staging',
-    name: 'demo-staging',
-    slug: 'demo-staging',
-    status: 'active',
-    namespace: 'wm-demo',
-    services: [
-      { id: 'stage-dashboard', name: 'dashboard', port: 3001, dnsHostname: 'dashboard.demo.local', vpnUrl: 'https://example.com' },
-    ],
-  },
-]
-
 export function SidebarBrowse() {
-  const { tabs, activeTabId, closeTab, setActiveTab, moveTab, addTab } = useTabStore()
-  const [envPickerOpen, setEnvPickerOpen] = useState(false)
-
-  const { environments, selectedEnvironmentId, setSelectedEnvironment } = useEnvironmentStore()
-  const browseEnvironments = environments.length > 0 ? environments : DUMMY_ENVIRONMENTS
-  const selectedEnv = browseEnvironments.find((e) => e.id === selectedEnvironmentId) ?? browseEnvironments[0]
+  const { tabs, activeTabId, closeTab, setActiveTab, moveTab } = useTabStore()
 
   function openNewTab() {
     window.dispatchEvent(new CustomEvent('open-command-bar'))
   }
 
-  function statusColor(status: Environment['status']) {
-    if (status === 'active') return 'bg-emerald-400'
-    if (status === 'error') return 'bg-red-400'
-    return 'bg-sidebar-foreground/30'
-  }
-
   return (
     <>
       <div className="flex min-h-0 flex-1 flex-col">
-        {/* Environment picker */}
-        <div className="shrink-0 px-3 pb-3">
-          <div className="px-3 pb-1.5 text-[10px] font-semibold uppercase tracking-wider text-sidebar-foreground/35">
-            Environments
-          </div>
-          <div className="relative">
-            <button
-              className="no-drag flex w-full items-center gap-2 rounded-lg px-3 py-2 text-[13px] font-medium text-sidebar-foreground/75 transition-colors hover:bg-sidebar-foreground/[0.06]"
-              onClick={() => setEnvPickerOpen(!envPickerOpen)}
-            >
-              <Globe className="h-4 w-4 shrink-0 text-sidebar-foreground/45" />
-              <span className={cn('h-1.5 w-1.5 rounded-full', selectedEnv ? statusColor(selectedEnv.status) : 'bg-sidebar-foreground/30')} />
-              <span className="min-w-0 flex-1 truncate text-left">{selectedEnv?.name || 'Select environment'}</span>
-              <span className="text-[11px] text-sidebar-foreground/35">{selectedEnv?.services.length ?? 0} services</span>
-              <ChevronDown className={cn('h-3.5 w-3.5 shrink-0 text-sidebar-foreground/45 transition-transform', envPickerOpen && 'rotate-180')} />
-            </button>
-            {envPickerOpen && (
-              <>
-              <div className="fixed inset-0 z-10" onClick={() => setEnvPickerOpen(false)} />
-              <div className="absolute left-0 right-0 top-full z-20 mt-1 overflow-hidden rounded-lg border border-sidebar-foreground/[0.08] bg-sidebar shadow-xl" style={{ animation: 'dropdown-in 150ms cubic-bezier(0.22,1,0.36,1)' }}>
-                {browseEnvironments.map((env) => (
-                  <button
-                    key={env.id}
-                    className={cn(
-                      'flex w-full items-center gap-2.5 px-3 py-2 text-left text-[12px] transition-colors',
-                      env.id === selectedEnv?.id
-                        ? 'bg-sidebar-foreground/[0.1] text-sidebar-foreground'
-                        : 'text-sidebar-foreground/65 hover:bg-sidebar-foreground/[0.06] hover:text-sidebar-foreground/85'
-                    )}
-                    onClick={() => {
-                      setSelectedEnvironment(env.id)
-                      setEnvPickerOpen(false)
-                    }}
-                  >
-                    <span className={cn('h-1.5 w-1.5 rounded-full', statusColor(env.status))} />
-                    <span className="min-w-0 flex-1 truncate">{env.name}</span>
-                    <span className="text-[10px] text-sidebar-foreground/35">{env.services.length} services</span>
-                  </button>
-                ))}
-              </div>
-              </>
-            )}
-          </div>
-        </div>
-
-        {/* Service list */}
-        {selectedEnv && (
-          <div className="shrink-0 px-3 pb-2">
-            <div className="px-3 pb-1.5 text-[10px] font-semibold uppercase tracking-wider text-sidebar-foreground/35">
-              HTTP services
-            </div>
-            <div className="flex flex-col">
-              {selectedEnv.services.map((svc) => (
-                <button
-                  key={svc.id}
-                  className="no-drag flex h-9 w-full items-center gap-3 rounded-lg px-3 text-left text-[13px] text-sidebar-foreground/70 transition-colors hover:bg-sidebar-foreground/[0.06] hover:text-sidebar-foreground/90"
-                  onClick={() => addTab(svc.vpnUrl)}
-                >
-                  <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400/70" />
-                  <span className="min-w-0 flex-1 truncate">{svc.name}</span>
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Separator */}
-        <div className="mx-5 my-2 shrink-0 border-t border-sidebar-foreground/[0.08]" />
-
         {/* New tab button */}
         <div className="shrink-0 px-3 pb-2">
           <button

--- a/web/apps/desktop/src/renderer/components/ui/dialog.tsx
+++ b/web/apps/desktop/src/renderer/components/ui/dialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 
 interface DialogProps {
   title: string
@@ -17,7 +18,7 @@ export function Dialog({ title, description, onClose, children, footer, maxWidth
     setTimeout(onClose, 150)
   }, [onClose])
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={close}>
       <div
         className="w-full overflow-hidden rounded-2xl border border-border/40 bg-popover shadow-2xl"
@@ -44,6 +45,7 @@ export function Dialog({ title, description, onClose, children, footer, maxWidth
           </div>
         )}
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/web/apps/desktop/src/renderer/components/webview-area.tsx
+++ b/web/apps/desktop/src/renderer/components/webview-area.tsx
@@ -156,6 +156,18 @@ export function WebviewArea({ onHandle }: WebviewAreaProps) {
               setNavFlash(direction)
               setTimeout(() => setNavFlash(null), 500)
             }
+          } else if (e.channel === 'shortcut') {
+            const store = useTabStore.getState()
+            if (store.activeTabId !== tabId || !readyRefs.current.has(tabId)) return
+            const action = e.args[0] as 'go-back' | 'go-forward' | 'reload' | 'next-tab' | 'prev-tab'
+            if (action === 'go-back') wv.goBack()
+            else if (action === 'go-forward') wv.goForward()
+            else if (action === 'reload') wv.reload()
+            else if (store.tabs.length > 1) {
+              const idx = store.tabs.findIndex((t) => t.id === store.activeTabId)
+              const offset = action === 'next-tab' ? 1 : -1
+              if (idx >= 0) store.setActiveTab(store.tabs[(idx + offset + store.tabs.length) % store.tabs.length].id)
+            }
           } else if (e.channel === 'page-metadata') {
             const metadata = e.args[0] as PageMetadata
             const currentUrl = wv.getURL()

--- a/web/apps/desktop/src/renderer/store/environments.ts
+++ b/web/apps/desktop/src/renderer/store/environments.ts
@@ -18,6 +18,30 @@ export interface Environment {
   ownedBy?: string
 }
 
+export const DUMMY_ENVIRONMENTS: Environment[] = [
+  {
+    id: 'demo-production',
+    name: 'demo-production',
+    slug: 'demo-production',
+    status: 'active',
+    namespace: 'wm-demo',
+    services: [
+      { id: 'prod-api', name: 'api', port: 8080, dnsHostname: 'api.demo.local', vpnUrl: 'https://www.google.com' },
+      { id: 'prod-web', name: 'web', port: 3000, dnsHostname: 'web.demo.local', vpnUrl: 'https://news.ycombinator.com' },
+    ],
+  },
+  {
+    id: 'demo-staging',
+    name: 'demo-staging',
+    slug: 'demo-staging',
+    status: 'active',
+    namespace: 'wm-demo',
+    services: [
+      { id: 'stage-dashboard', name: 'dashboard', port: 3001, dnsHostname: 'dashboard.demo.local', vpnUrl: 'https://example.com' },
+    ],
+  },
+]
+
 interface EnvironmentStore {
   environments: Environment[]
   selectedEnvironmentId: string | null


### PR DESCRIPTION
## Summary\n- keep desktop shortcuts app-scoped with focused window/webview handling, no OS-level global capture\n- move browse services into the new-tab picker with env/service labels\n- simplify browse sidebar and portal dialogs above webviews\n\n## Checks\n- cd web/apps/desktop && bunx tsc -b --noEmit